### PR TITLE
Add atmospheric modelling package with LLM post-processing pipeline

### DIFF
--- a/scripts/predict_soil_moisture.py
+++ b/scripts/predict_soil_moisture.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""CLI entry-point for the soil moisture prediction pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from atmo_model.core import AtmosphericState
+from atmo_model.pipeline import predict_three_day_soil_moisture
+
+
+def _load_state(path: Path) -> AtmosphericState:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return AtmosphericState.from_dict(data)
+
+
+def _load_weather(path: Path) -> Iterable[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, dict):
+        data = data.get("weather", [])
+    if not isinstance(data, list):
+        raise ValueError("Weather data must be a list of hourly entries")
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("initial_state", type=Path, help="Path to a JSON file containing the initial atmospheric state")
+    parser.add_argument("weather_data", type=Path, help="Path to a JSON file containing hourly weather forecasts")
+    parser.add_argument("--output", type=Path, default=Path("soil_moisture_forecast.json"), help="Output path for the generated forecast")
+    args = parser.parse_args()
+
+    initial_state = _load_state(args.initial_state)
+    weather_data = _load_weather(args.weather_data)
+
+    forecast = predict_three_day_soil_moisture(initial_state, weather_data)
+
+    serialisable = {
+        "issued_at": forecast.issued_at.isoformat(),
+        "horizon_hours": forecast.horizon_hours,
+        "soil_moisture": forecast.values,
+        "metadata": forecast.metadata,
+    }
+
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(serialisable, handle, indent=2)
+
+    print(f"Forecast saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/atmo_model/__init__.py
+++ b/src/atmo_model/__init__.py
@@ -1,0 +1,21 @@
+"""Atmospheric modelling package."""
+
+from .core import (
+    AtmosphericModel,
+    AtmosphericState,
+    DeterministicAtmosphericModel,
+    SoilMoistureForecast,
+    evolve_state,
+    export_soil_moisture_features,
+    load_numerical_weather_outputs,
+)
+
+__all__ = [
+    "AtmosphericModel",
+    "AtmosphericState",
+    "DeterministicAtmosphericModel",
+    "SoilMoistureForecast",
+    "evolve_state",
+    "export_soil_moisture_features",
+    "load_numerical_weather_outputs",
+]

--- a/src/atmo_model/core.py
+++ b/src/atmo_model/core.py
@@ -1,0 +1,183 @@
+"""Core data structures and deterministic atmospheric modelling utilities."""
+
+from __future__ import annotations
+
+import datetime as dt
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+def _ensure_timestamp(value: dt.datetime | str) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value
+    return dt.datetime.fromisoformat(value)
+
+
+@dataclass
+class AtmosphericState:
+    """Represents the atmospheric state at a specific timestamp."""
+
+    timestamp: dt.datetime
+    temperature_c: float
+    relative_humidity: float
+    precipitation_mm: float
+    soil_moisture: float
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "AtmosphericState":
+        return cls(
+            timestamp=_ensure_timestamp(payload["timestamp"]),
+            temperature_c=float(payload["temperature_c"]),
+            relative_humidity=float(payload["relative_humidity"]),
+            precipitation_mm=float(payload["precipitation_mm"]),
+            soil_moisture=float(payload.get("soil_moisture", 0.0)),
+        )
+
+
+@dataclass
+class SoilMoistureForecast:
+    """Container for soil moisture forecasts at an hourly resolution."""
+
+    issued_at: dt.datetime
+    horizon_hours: int
+    values: List[float] = field(default_factory=list)
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+    def to_daily_averages(self, hours_per_day: int = 24) -> List[float]:
+        """Return daily averages over the stored hourly predictions."""
+
+        averages: List[float] = []
+        for day in range(0, self.horizon_hours, hours_per_day):
+            chunk = self.values[day : day + hours_per_day]
+            if not chunk:
+                break
+            averages.append(sum(chunk) / len(chunk))
+        return averages
+
+
+class AtmosphericModel(ABC):
+    """Abstract interface for atmospheric forecast models."""
+
+    @abstractmethod
+    def predict(
+        self,
+        initial_state: AtmosphericState,
+        weather_inputs: Sequence[Dict[str, float]],
+        hours_ahead: int,
+    ) -> List[AtmosphericState]:
+        """Predict the evolution of the atmospheric state."""
+
+
+class DeterministicAtmosphericModel(AtmosphericModel):
+    """A lightweight, fully deterministic atmospheric model.
+
+    The model relies on simplified heuristics that provide deterministic
+    outputs suitable for unit tests and offline experimentation.
+    """
+
+    def __init__(self, evaporation_rate: float = 0.015, percolation_rate: float = 0.01):
+        self.evaporation_rate = evaporation_rate
+        self.percolation_rate = percolation_rate
+
+    def predict(
+        self,
+        initial_state: AtmosphericState,
+        weather_inputs: Sequence[Dict[str, float]],
+        hours_ahead: int,
+    ) -> List[AtmosphericState]:
+        states: List[AtmosphericState] = []
+        current_state = initial_state
+        time_step = dt.timedelta(hours=1)
+
+        for hour in range(min(hours_ahead, len(weather_inputs))):
+            weather = weather_inputs[hour]
+            current_state = evolve_state(current_state, weather, time_step, self)
+            states.append(current_state)
+        return states
+
+
+def load_numerical_weather_outputs(
+    raw_weather_data: Iterable[Dict[str, object]]
+) -> List[Dict[str, float]]:
+    """Normalise numerical weather prediction outputs.
+
+    Parameters
+    ----------
+    raw_weather_data:
+        Iterable of mapping objects containing at least temperature, humidity and
+        precipitation. Any missing field defaults to 0.0.
+    """
+
+    normalised: List[Dict[str, float]] = []
+    for index, entry in enumerate(raw_weather_data):
+        temperature = float(entry.get("temperature_c", 0.0))
+        humidity = float(entry.get("relative_humidity", 0.0))
+        precipitation = float(entry.get("precipitation_mm", 0.0))
+        normalised.append(
+            {
+                "temperature_c": temperature,
+                "relative_humidity": humidity,
+                "precipitation_mm": precipitation,
+                "hour_index": float(entry.get("hour_index", index)),
+            }
+        )
+    return normalised
+
+
+def evolve_state(
+    state: AtmosphericState,
+    weather: Dict[str, float],
+    step: dt.timedelta,
+    model: DeterministicAtmosphericModel,
+) -> AtmosphericState:
+    """Evolve the atmospheric state by one time step.
+
+    The model applies a simplified mass balance between precipitation and
+    evapotranspiration. Soil moisture is kept within the ``[0, 1]`` interval.
+    """
+
+    hours = step.total_seconds() / 3600.0
+    temperature = weather["temperature_c"]
+    humidity = weather["relative_humidity"]
+    precipitation = weather["precipitation_mm"]
+
+    evapotranspiration = (1 - humidity / 100.0) * model.evaporation_rate * hours
+    infiltration = precipitation * model.percolation_rate * hours
+
+    new_soil_moisture = state.soil_moisture + infiltration - evapotranspiration
+    new_soil_moisture = max(0.0, min(1.0, new_soil_moisture))
+
+    return AtmosphericState(
+        timestamp=state.timestamp + step,
+        temperature_c=temperature,
+        relative_humidity=humidity,
+        precipitation_mm=precipitation,
+        soil_moisture=new_soil_moisture,
+    )
+
+
+def export_soil_moisture_features(
+    states: Sequence[AtmosphericState],
+) -> Dict[str, float]:
+    """Export deterministic features that help the LLM estimate soil moisture."""
+
+    if not states:
+        return {
+            "mean_temperature": 0.0,
+            "mean_humidity": 0.0,
+            "total_precipitation": 0.0,
+            "final_soil_moisture": 0.0,
+        }
+
+    mean_temperature = sum(s.temperature_c for s in states) / len(states)
+    mean_humidity = sum(s.relative_humidity for s in states) / len(states)
+    total_precipitation = sum(s.precipitation_mm for s in states)
+    final_soil_moisture = states[-1].soil_moisture
+
+    return {
+        "mean_temperature": mean_temperature,
+        "mean_humidity": mean_humidity,
+        "total_precipitation": total_precipitation,
+        "final_soil_moisture": final_soil_moisture,
+    }

--- a/src/atmo_model/llm_postprocessing.py
+++ b/src/atmo_model/llm_postprocessing.py
@@ -1,0 +1,119 @@
+"""Utilities for formatting and parsing LLM powered soil moisture estimates."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+from .core import AtmosphericState, SoilMoistureForecast
+
+LLMClient = Callable[[str], Any]
+
+
+@dataclass
+class LLMPostProcessor:
+    """Handle LLM based soil moisture post processing.
+
+    Parameters
+    ----------
+    client:
+        A callable that accepts a string prompt and returns a model response. The
+        response may be raw text, a ``dict`` or a list containing a string.
+    """
+
+    client: Optional[LLMClient] = None
+    horizon_hours: int = 72
+
+    def build_prompt(
+        self,
+        initial_state: AtmosphericState,
+        projected_states: Sequence[AtmosphericState],
+        features: Dict[str, float],
+    ) -> str:
+        """Format a prompt describing the atmospheric evolution."""
+
+        state_lines = []
+        for state in projected_states:
+            state_lines.append(
+                f"{state.timestamp.isoformat()} | T={state.temperature_c:.1f}C | "
+                f"RH={state.relative_humidity:.1f}% | P={state.precipitation_mm:.2f}mm | "
+                f"SM={state.soil_moisture:.3f}"
+            )
+
+        feature_lines = "\n".join(f"- {name}: {value:.3f}" for name, value in sorted(features.items()))
+
+        prompt = (
+            "You are an expert hydrologist. Based on the projected atmospheric "
+            "states, estimate the soil moisture for the next 72 hours in hourly "
+            "increments. Return the results as a JSON object with the key "
+            "'soil_moisture' containing a list of 72 decimal numbers between 0 and 1.\n"
+            "Initial state: "
+            f"T={initial_state.temperature_c:.1f}C, RH={initial_state.relative_humidity:.1f}%, "
+            f"P={initial_state.precipitation_mm:.2f}mm, SM={initial_state.soil_moisture:.3f}.\n"
+            "Projected states (hourly):\n"
+            + "\n".join(state_lines)
+            + "\nKey summary features:\n"
+            + feature_lines
+        )
+        return prompt
+
+    def _call_client(self, prompt: str) -> Any:
+        if self.client is None:
+            raise RuntimeError("No LLM client configured for post-processing")
+        return self.client(prompt)
+
+    def _coerce_response_text(self, response: Any) -> str:
+        if isinstance(response, str):
+            return response
+        if isinstance(response, dict):
+            return json.dumps(response)
+        if isinstance(response, (list, tuple)) and response:
+            return self._coerce_response_text(response[0])
+        return str(response)
+
+    def parse_response(self, response: Any) -> List[float]:
+        """Parse an LLM response into 72 hourly soil moisture values."""
+
+        text = self._coerce_response_text(response)
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            numbers = [float(value) for value in re.findall(r"[-+]?[0-9]*\.?[0-9]+", text)]
+            return numbers[: self.horizon_hours]
+
+        if isinstance(data, dict) and "soil_moisture" in data:
+            values = data["soil_moisture"]
+        else:
+            values = data
+
+        if not isinstance(values, Iterable):
+            raise ValueError("LLM response does not contain an iterable of values")
+
+        result: List[float] = []
+        for value in values:
+            try:
+                result.append(float(value))
+            except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError("Invalid soil moisture value in LLM response") from exc
+        return result[: self.horizon_hours]
+
+    def postprocess(
+        self,
+        initial_state: AtmosphericState,
+        projected_states: Sequence[AtmosphericState],
+        features: Dict[str, float],
+    ) -> SoilMoistureForecast:
+        """Run the LLM client and convert the response into a forecast."""
+
+        prompt = self.build_prompt(initial_state, projected_states, features)
+        response = self._call_client(prompt)
+        values = self.parse_response(response)
+
+        return SoilMoistureForecast(
+            issued_at=projected_states[0].timestamp if projected_states else initial_state.timestamp,
+            horizon_hours=self.horizon_hours,
+            values=values,
+            metadata={"prompt": prompt},
+        )

--- a/src/atmo_model/pipeline.py
+++ b/src/atmo_model/pipeline.py
@@ -1,0 +1,49 @@
+"""High level orchestration for soil moisture predictions."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Iterable, Optional
+
+from .core import (
+    AtmosphericState,
+    DeterministicAtmosphericModel,
+    SoilMoistureForecast,
+    export_soil_moisture_features,
+    load_numerical_weather_outputs,
+)
+from .llm_postprocessing import LLMPostProcessor
+
+
+def predict_three_day_soil_moisture(
+    initial_state: AtmosphericState,
+    weather_data: Iterable[dict],
+    *,
+    model: Optional[DeterministicAtmosphericModel] = None,
+    post_processor: Optional[LLMPostProcessor] = None,
+) -> SoilMoistureForecast:
+    """Predict soil moisture 72 hours in advance using the deterministic pipeline."""
+
+    model = model or DeterministicAtmosphericModel()
+    post_processor = post_processor or LLMPostProcessor()
+
+    normalised_weather = load_numerical_weather_outputs(weather_data)
+
+    hours_ahead = post_processor.horizon_hours
+    projected_states = model.predict(initial_state, normalised_weather, hours_ahead)
+
+    features = export_soil_moisture_features(projected_states)
+
+    forecast = post_processor.postprocess(initial_state, projected_states, features)
+
+    if len(forecast.values) < hours_ahead:
+        extended = list(forecast.values)
+        last_value = extended[-1] if extended else initial_state.soil_moisture
+        while len(extended) < hours_ahead:
+            extended.append(last_value)
+        forecast.values = extended
+
+    forecast.metadata.setdefault("issued_at", dt.datetime.utcnow().isoformat())
+    forecast.metadata["features"] = features
+
+    return forecast

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_llm_postprocessing.py
+++ b/tests/test_llm_postprocessing.py
@@ -1,0 +1,82 @@
+import datetime as dt
+from typing import Any, Dict, List
+
+import pytest
+
+from atmo_model.core import AtmosphericState, DeterministicAtmosphericModel
+from atmo_model.llm_postprocessing import LLMPostProcessor
+from atmo_model.pipeline import predict_three_day_soil_moisture
+
+
+class DummyLLMClient:
+    def __init__(self, response: Any):
+        self.received_prompts: List[str] = []
+        self.response = response
+
+    def __call__(self, prompt: str) -> Any:
+        self.received_prompts.append(prompt)
+        return self.response
+
+
+def _sample_state() -> AtmosphericState:
+    return AtmosphericState(
+        timestamp=dt.datetime(2024, 1, 1, 0, 0, 0),
+        temperature_c=18.0,
+        relative_humidity=60.0,
+        precipitation_mm=0.5,
+        soil_moisture=0.4,
+    )
+
+
+def _sample_weather(hours: int = 72) -> List[Dict[str, float]]:
+    return [
+        {
+            "timestamp": (dt.datetime(2024, 1, 1) + dt.timedelta(hours=hour)).isoformat(),
+            "temperature_c": 18.0 + hour * 0.05,
+            "relative_humidity": 55.0 + hour * 0.1,
+            "precipitation_mm": 0.2 if hour % 6 == 0 else 0.0,
+        }
+        for hour in range(hours)
+    ]
+
+
+def test_prompt_includes_features_and_states():
+    state = _sample_state()
+    weather = _sample_weather(3)
+    processor = LLMPostProcessor(client=DummyLLMClient({"soil_moisture": [0.4] * 72}))
+    model = DeterministicAtmosphericModel()
+
+    projected_states = model.predict(state, weather, 3)
+    features = {
+        "mean_temperature": 19.0,
+        "mean_humidity": 62.0,
+        "total_precipitation": 0.4,
+        "final_soil_moisture": 0.45,
+    }
+
+    prompt = processor.build_prompt(state, projected_states, features)
+
+    assert "mean_temperature" in prompt
+    assert "Projected states" in prompt
+    assert "SM=" in prompt
+
+
+def test_parse_response_handles_json():
+    processor = LLMPostProcessor()
+    response = {"soil_moisture": [0.5] * 100}
+    parsed = processor.parse_response(response)
+    assert parsed == [0.5] * processor.horizon_hours
+
+
+def test_pipeline_with_mocked_llm_returns_forecast():
+    state = _sample_state()
+    weather = _sample_weather(72)
+    fake_values = [0.4 + i * 0.001 for i in range(72)]
+    processor = LLMPostProcessor(client=DummyLLMClient({"soil_moisture": fake_values}))
+
+    forecast = predict_three_day_soil_moisture(state, weather, post_processor=processor)
+
+    assert len(forecast.values) == 72
+    assert forecast.values == fake_values
+    assert "features" in forecast.metadata
+    assert "prompt" in forecast.metadata


### PR DESCRIPTION
## Summary
- add deterministic atmospheric modelling core with state utilities and forecasting interface
- introduce LLM post-processing module and three-day soil moisture pipeline with CLI
- cover prompt formatting, response parsing, and pipeline integration with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68da6c8d4768832ea2267080191d4dbd